### PR TITLE
Reactivate scrollbar for float editor

### DIFF
--- a/dist/chunks/chunk.VU4BY5FN.js
+++ b/dist/chunks/chunk.VU4BY5FN.js
@@ -1229,11 +1229,8 @@ FloatEditor.styles = [
                 padding: var(--edit-fz-spacing-small);
                 background-color: var(--sys-color-neutral-0);
                 border-radius: 0 0 var(--edit-fz-border-radius-small) var(--edit-fz-border-radius-small);
-
-                // some editors need to open other popups that overflow outside of the editor
-                // this is breaking them.
-                //max-height: 540px;
-                //overflow: auto;
+                max-height: 540px;
+                overflow: auto;
             }
             .loading {
                 width: 100%;

--- a/dist/common/common.js
+++ b/dist/common/common.js
@@ -19,7 +19,7 @@ import {
   waitForEvent,
   widgetEmit,
   widgetEmitPromise
-} from "../chunks/chunk.GHRRSMAG.js";
+} from "../chunks/chunk.VU4BY5FN.js";
 import {
   FetchService
 } from "../chunks/chunk.BTK3NVPD.js";

--- a/dist/index.js
+++ b/dist/index.js
@@ -19,7 +19,7 @@ import {
   waitForEvent,
   widgetEmit,
   widgetEmitPromise
-} from "./chunks/chunk.GHRRSMAG.js";
+} from "./chunks/chunk.VU4BY5FN.js";
 import {
   ClientSDK,
   FetchService

--- a/src/common/FloatEditor.ts
+++ b/src/common/FloatEditor.ts
@@ -94,11 +94,8 @@ export class FloatEditor extends LitElement {
                 padding: var(--edit-fz-spacing-small);
                 background-color: var(--sys-color-neutral-0);
                 border-radius: 0 0 var(--edit-fz-border-radius-small) var(--edit-fz-border-radius-small);
-
-                // some editors need to open other popups that overflow outside of the editor
-                // this is breaking them.
-                //max-height: 540px;
-                //overflow: auto;
+                max-height: 540px;
+                overflow: auto;
             }
             .loading {
                 width: 100%;


### PR DESCRIPTION
Enabling scrollbar for float editor. There was an issue related to Quill dropdowns but it will be fixed on the widgets repo.