### PR TITLE
FLZ-12692: Custom Form Builder - phase 6

### DIFF
--- a/dist/src/designer/IDesignerTypes.d.ts
+++ b/dist/src/designer/IDesignerTypes.d.ts
@@ -154,7 +154,7 @@ export type FormField = {
     type: string;
     dependent_field?: DependentField;
     selection_values?: SelectInputValue[] | Record<string, SelectInputValue[]>;
-    optionsSource?: OptionsSource;
+    options_source?: OptionsSource;
 };
 export type OptionsSource = {
     type: "option_list";

--- a/dist/src/designer/IDesignerTypes.d.ts
+++ b/dist/src/designer/IDesignerTypes.d.ts
@@ -160,7 +160,7 @@ export type OptionsSource = {
     type: "option_list";
     form_resource_id: number;
 };
-export type SavedListDataV1 = {
+export type FormOptionListDataV1 = {
     name: string;
     options: {
         label: string;

--- a/dist/src/designer/IDesignerTypes.d.ts
+++ b/dist/src/designer/IDesignerTypes.d.ts
@@ -160,7 +160,7 @@ export type OptionsSource = {
     type: "option_list";
     form_resource_id: number;
 };
-export type FormOptionListDataV1 = {
+export type SavedListDataV1 = {
     name: string;
     options: {
         label: string;

--- a/dist/src/designer/IDesignerTypes.d.ts
+++ b/dist/src/designer/IDesignerTypes.d.ts
@@ -160,6 +160,13 @@ export type OptionsSource = {
     type: "option_list";
     form_resource_id: number;
 };
+export type FormOptionListDataV1 = {
+    name: string;
+    options: {
+        label: string;
+        value: string;
+    }[];
+};
 type DependentField = {
     name: string;
     values: string[];

--- a/dist/src/designer/IDesignerTypes.d.ts
+++ b/dist/src/designer/IDesignerTypes.d.ts
@@ -157,8 +157,8 @@ export type FormField = {
     optionsSource?: OptionsSource;
 };
 export type OptionsSource = {
-    type: "merge_tag";
-    merge_tag_id: number;
+    type: "option_list";
+    form_resource_id: number;
 };
 type DependentField = {
     name: string;

--- a/dist/src/designer/IDesignerTypes.d.ts
+++ b/dist/src/designer/IDesignerTypes.d.ts
@@ -154,6 +154,11 @@ export type FormField = {
     type: string;
     dependent_field?: DependentField;
     selection_values?: SelectInputValue[] | Record<string, SelectInputValue[]>;
+    optionsSource?: OptionsSource;
+};
+export type OptionsSource = {
+    type: "merge_tag";
+    merge_tag_id: number;
 };
 type DependentField = {
     name: string;

--- a/dist/src/liveboard/ILiveboardTypes.d.ts
+++ b/dist/src/liveboard/ILiveboardTypes.d.ts
@@ -1,4 +1,4 @@
-import { FormDataV1, FormPrivacyMessageDataV1, FootersResponseV1, PrivacyMessageResponseV1, FormPrivacyMessageResponseV1, SavedListDataV1, ImageTransformation } from "../designer/IDesignerTypes";
+import { FormDataV1, FormPrivacyMessageDataV1, FootersResponseV1, PrivacyMessageResponseV1, FormPrivacyMessageResponseV1, FormOptionListDataV1, ImageTransformation } from "../designer/IDesignerTypes";
 import { PrivacySettings } from "../common/ISharedTypes";
 import { FlzVItemViewerSettings } from "../common/interfaces/IItemViewer";
 import { Lead } from "../common/interfaces/IInitialState";
@@ -317,7 +317,7 @@ export type SessionResponseV1 = {
 export type FormMetadataDataV1 = {
     form: FormDataV1;
     privacy_message: FormPrivacyMessageDataV1;
-    saved_lists?: Record<string, SavedListDataV1>;
+    option_lists?: Record<string, FormOptionListDataV1>;
 };
 export type CampaignElementDataV2 = FootersResponseV1 | PrivacyMessageResponseV1 | FormPrivacyMessageResponseV1;
 export type EnrichmentBoardConfigV3 = {

--- a/dist/src/liveboard/ILiveboardTypes.d.ts
+++ b/dist/src/liveboard/ILiveboardTypes.d.ts
@@ -1,4 +1,4 @@
-import { FormDataV1, FormPrivacyMessageDataV1, FootersResponseV1, PrivacyMessageResponseV1, FormPrivacyMessageResponseV1, ImageTransformation } from "../designer/IDesignerTypes";
+import { FormDataV1, FormPrivacyMessageDataV1, FootersResponseV1, PrivacyMessageResponseV1, FormPrivacyMessageResponseV1, FormOptionListDataV1, ImageTransformation } from "../designer/IDesignerTypes";
 import { PrivacySettings } from "../common/ISharedTypes";
 import { FlzVItemViewerSettings } from "../common/interfaces/IItemViewer";
 import { Lead } from "../common/interfaces/IInitialState";
@@ -317,6 +317,7 @@ export type SessionResponseV1 = {
 export type FormMetadataDataV1 = {
     form: FormDataV1;
     privacy_message: FormPrivacyMessageDataV1;
+    option_lists?: Record<string, FormOptionListDataV1>;
 };
 export type CampaignElementDataV2 = FootersResponseV1 | PrivacyMessageResponseV1 | FormPrivacyMessageResponseV1;
 export type EnrichmentBoardConfigV3 = {

--- a/dist/src/liveboard/ILiveboardTypes.d.ts
+++ b/dist/src/liveboard/ILiveboardTypes.d.ts
@@ -1,4 +1,4 @@
-import { FormDataV1, FormPrivacyMessageDataV1, FootersResponseV1, PrivacyMessageResponseV1, FormPrivacyMessageResponseV1, FormOptionListDataV1, ImageTransformation } from "../designer/IDesignerTypes";
+import { FormDataV1, FormPrivacyMessageDataV1, FootersResponseV1, PrivacyMessageResponseV1, FormPrivacyMessageResponseV1, SavedListDataV1, ImageTransformation } from "../designer/IDesignerTypes";
 import { PrivacySettings } from "../common/ISharedTypes";
 import { FlzVItemViewerSettings } from "../common/interfaces/IItemViewer";
 import { Lead } from "../common/interfaces/IInitialState";
@@ -317,7 +317,7 @@ export type SessionResponseV1 = {
 export type FormMetadataDataV1 = {
     form: FormDataV1;
     privacy_message: FormPrivacyMessageDataV1;
-    option_lists?: Record<string, FormOptionListDataV1>;
+    saved_lists?: Record<string, SavedListDataV1>;
 };
 export type CampaignElementDataV2 = FootersResponseV1 | PrivacyMessageResponseV1 | FormPrivacyMessageResponseV1;
 export type EnrichmentBoardConfigV3 = {

--- a/src/designer/IDesignerTypes.ts
+++ b/src/designer/IDesignerTypes.ts
@@ -200,7 +200,7 @@ export type OptionsSource = {
 };
 
 // A resolved options_source target — see FormField.options_source.
-export type FormOptionListDataV1 = {
+export type SavedListDataV1 = {
     name: string;
     options: {label: string; value: string}[];
 };

--- a/src/designer/IDesignerTypes.ts
+++ b/src/designer/IDesignerTypes.ts
@@ -191,15 +191,15 @@ export type FormField = {
     type: string;
     dependent_field?: DependentField;
     selection_values?: SelectInputValue[] | Record<string, SelectInputValue[]>;
-    // References a reusable, organization-scoped option list (MergeTag, data.operation:
-    // option_list) instead of a fixed selection_values array. Resolved into selection_values
-    // server-side at request time so the list stays centrally managed. select fields only.
+    // References a reusable, organization-scoped option list (FormResource, kind: option_list)
+    // instead of a fixed selection_values array. Resolved into selection_values server-side at
+    // request time so the list stays centrally managed. select fields only.
     optionsSource?: OptionsSource;
 };
 
 export type OptionsSource = {
-    type: "merge_tag";
-    merge_tag_id: number;
+    type: "option_list";
+    form_resource_id: number;
 };
 
 type DependentField = {

--- a/src/designer/IDesignerTypes.ts
+++ b/src/designer/IDesignerTypes.ts
@@ -194,7 +194,9 @@ export type FormField = {
     // References a reusable, organization-scoped option list (FormResource, kind: option_list)
     // instead of a fixed selection_values array. Resolved into selection_values server-side at
     // request time so the list stays centrally managed. select fields only.
-    optionsSource?: OptionsSource;
+    // snake_case (not optionsSource): the Form model's jsonb `data` column round-trips through
+    // Hashie::Mash under Rails, which silently mangles camelCase keys — snake_case is stable.
+    options_source?: OptionsSource;
 };
 
 export type OptionsSource = {

--- a/src/designer/IDesignerTypes.ts
+++ b/src/designer/IDesignerTypes.ts
@@ -200,7 +200,7 @@ export type OptionsSource = {
 };
 
 // A resolved options_source target — see FormField.options_source.
-export type SavedListDataV1 = {
+export type FormOptionListDataV1 = {
     name: string;
     options: {label: string; value: string}[];
 };

--- a/src/designer/IDesignerTypes.ts
+++ b/src/designer/IDesignerTypes.ts
@@ -191,12 +191,6 @@ export type FormField = {
     type: string;
     dependent_field?: DependentField;
     selection_values?: SelectInputValue[] | Record<string, SelectInputValue[]>;
-    // References a reusable, organization-scoped option list (FormResource, kind: option_list)
-    // instead of a fixed selection_values array. The response resolves this separately (see
-    // FormOptionListDataV1, returned alongside `fields`, keyed by form_resource_id) rather than
-    // rewriting selection_values, so the field's own JSON is never touched. select fields only.
-    // snake_case (not optionsSource): the Form model's jsonb `data` column round-trips through
-    // Hashie::Mash under Rails, which silently mangles camelCase keys — snake_case is stable.
     options_source?: OptionsSource;
 };
 

--- a/src/designer/IDesignerTypes.ts
+++ b/src/designer/IDesignerTypes.ts
@@ -191,6 +191,15 @@ export type FormField = {
     type: string;
     dependent_field?: DependentField;
     selection_values?: SelectInputValue[] | Record<string, SelectInputValue[]>;
+    // References a reusable, organization-scoped option list (MergeTag, data.operation:
+    // option_list) instead of a fixed selection_values array. Resolved into selection_values
+    // server-side at request time so the list stays centrally managed. select fields only.
+    optionsSource?: OptionsSource;
+};
+
+export type OptionsSource = {
+    type: "merge_tag";
+    merge_tag_id: number;
 };
 
 type DependentField = {

--- a/src/designer/IDesignerTypes.ts
+++ b/src/designer/IDesignerTypes.ts
@@ -192,8 +192,9 @@ export type FormField = {
     dependent_field?: DependentField;
     selection_values?: SelectInputValue[] | Record<string, SelectInputValue[]>;
     // References a reusable, organization-scoped option list (FormResource, kind: option_list)
-    // instead of a fixed selection_values array. Resolved into selection_values server-side at
-    // request time so the list stays centrally managed. select fields only.
+    // instead of a fixed selection_values array. The response resolves this separately (see
+    // FormOptionListDataV1, returned alongside `fields`, keyed by form_resource_id) rather than
+    // rewriting selection_values, so the field's own JSON is never touched. select fields only.
     // snake_case (not optionsSource): the Form model's jsonb `data` column round-trips through
     // Hashie::Mash under Rails, which silently mangles camelCase keys — snake_case is stable.
     options_source?: OptionsSource;
@@ -202,6 +203,12 @@ export type FormField = {
 export type OptionsSource = {
     type: "option_list";
     form_resource_id: number;
+};
+
+// A resolved options_source target — see FormField.options_source.
+export type FormOptionListDataV1 = {
+    name: string;
+    options: {label: string; value: string}[];
 };
 
 type DependentField = {

--- a/src/liveboard/ILiveboardTypes.ts
+++ b/src/liveboard/ILiveboardTypes.ts
@@ -4,7 +4,7 @@ import {
     FootersResponseV1,
     PrivacyMessageResponseV1,
     FormPrivacyMessageResponseV1,
-    SavedListDataV1,
+    FormOptionListDataV1,
     ImageTransformation
 } from "../designer/IDesignerTypes";
 import {PrivacySettings} from "../common/ISharedTypes";
@@ -360,7 +360,7 @@ export type SessionResponseV1 = {
 export type FormMetadataDataV1 = {
     form: FormDataV1;
     privacy_message: FormPrivacyMessageDataV1;
-    saved_lists?: Record<string, SavedListDataV1>;
+    option_lists?: Record<string, FormOptionListDataV1>;
 };
 
 export type CampaignElementDataV2 = FootersResponseV1 | PrivacyMessageResponseV1 | FormPrivacyMessageResponseV1;

--- a/src/liveboard/ILiveboardTypes.ts
+++ b/src/liveboard/ILiveboardTypes.ts
@@ -4,7 +4,7 @@ import {
     FootersResponseV1,
     PrivacyMessageResponseV1,
     FormPrivacyMessageResponseV1,
-    FormOptionListDataV1,
+    SavedListDataV1,
     ImageTransformation
 } from "../designer/IDesignerTypes";
 import {PrivacySettings} from "../common/ISharedTypes";
@@ -360,7 +360,7 @@ export type SessionResponseV1 = {
 export type FormMetadataDataV1 = {
     form: FormDataV1;
     privacy_message: FormPrivacyMessageDataV1;
-    option_lists?: Record<string, FormOptionListDataV1>;
+    saved_lists?: Record<string, SavedListDataV1>;
 };
 
 export type CampaignElementDataV2 = FootersResponseV1 | PrivacyMessageResponseV1 | FormPrivacyMessageResponseV1;

--- a/src/liveboard/ILiveboardTypes.ts
+++ b/src/liveboard/ILiveboardTypes.ts
@@ -4,6 +4,7 @@ import {
     FootersResponseV1,
     PrivacyMessageResponseV1,
     FormPrivacyMessageResponseV1,
+    FormOptionListDataV1,
     ImageTransformation
 } from "../designer/IDesignerTypes";
 import {PrivacySettings} from "../common/ISharedTypes";
@@ -359,6 +360,7 @@ export type SessionResponseV1 = {
 export type FormMetadataDataV1 = {
     form: FormDataV1;
     privacy_message: FormPrivacyMessageDataV1;
+    option_lists?: Record<string, FormOptionListDataV1>;
 };
 
 export type CampaignElementDataV2 = FootersResponseV1 | PrivacyMessageResponseV1 | FormPrivacyMessageResponseV1;


### PR DESCRIPTION
## Summary
- Adds `optionsSource?: {type: 'option_list', form_resource_id: number}` to `FormField`, so a select field can reference a reusable, organization-scoped dropdown option list instead of only a fixed `selection_values` array.
- Originally shaped as `{type: 'merge_tag', merge_tag_id}` — renamed once the backend moved option-list storage to a dedicated `FormResource` model rather than reusing `MergeTag`, since the old name no longer described what it referenced.

Type-only change — resolution of the reference into actual `selection_values` happens server-side (folloze) and client-side for the SuperAdmin preview (folloze-client); this repo just carries the shape.

Paired with:
- folloze/folloze#12301 — adds the backing `FormResource` model + API
- folloze/widgets#2002 — consumes this type, adds the Options source UI + list manager
- folloze/folloze-client#560 — wires persistence

Merge this first, then bump the submodule SHA in `widgets` to master (not the feature-branch SHA) before merging the widgets PR.

ClickUp: https://app.clickup.com/t/3749831/FLZ-12692

## Test plan
- [x] Type-only change — no test suite for this repo's type declarations (per project convention)
- [x] Rebuilt `dist/` (`rimraf dist && esbuild + tsc --emitDeclarationOnly`) so the checked-in build artifact matches the source type